### PR TITLE
Fix #7 (require 1 or more digit after e in parsing floats)

### DIFF
--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -1,4 +1,4 @@
-cabal-version:       1.14
+cabal-version:       1.14.0.1
 name:                HsYAML
 version:             0.2.0.0
 
@@ -67,7 +67,7 @@ library
                        Trustworthy
                        TypeSynonymInstances
 
-  build-depends:       base         >=4.5   && <4.12
+  build-depends:       base         >=4.5   && <4.13
                      , bytestring   >=0.9   && <0.11
                      , dlist        >=0.8   && <0.9
                      , containers   >=0.4.2 && <0.6

--- a/src/Data/YAML/Schema.hs
+++ b/src/Data/YAML/Schema.hs
@@ -310,7 +310,7 @@ coreDecodeFloat t
       p2 <- option "" $ do
         void (char 'e' P.<|> char 'E')
         s <- option "" (("-" <$ char '-') P.<|> ("" <$ char '+'))
-        d <- P.many digit
+        d <- P.many1 digit
 
         pure ("e" ++ s ++ d)
 


### PR DESCRIPTION
This PR also bumps the upper bound for base so that the library can compile with ghc 8.6.x.
