### PR TITLE
Additional feature to preserve Literal/Folded ScalarStyle

### DIFF
--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -159,7 +159,6 @@ cmdYaml2Event = do
       hPutStrLn stdout (ev2str True event)
       hFlush stdout
 
-
 cmdYaml2Event0 :: IO ()
 cmdYaml2Event0 = do
     inYamlDat <- BS.L.getContents

--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -462,8 +462,8 @@ ev2str withColSty = \case
     styStr = \case
            Plain        -> " :"
            DoubleQuoted -> " \""
-           Literal      -> " |"
-           Folded       -> " >"
+           Literal _ _  -> " |"
+           Folded  _ _  -> " >"
            SingleQuoted -> " '"
 
     ancTagStr manc mtag = anc' ++ tag'

--- a/src/Data/YAML/Event.hs
+++ b/src/Data/YAML/Event.hs
@@ -286,8 +286,8 @@ goNode0 DInfo {..} = goNode
         go0 ii sty (Y.Token { Y.tCode = Y.Indicator, Y.tText = ind } : rest)
           | "'"  <- ind = go' ii "" SingleQuoted rest
           | "\"" <- ind = go' ii "" DoubleQuoted rest
-          | "|"  <- ind = go0 True (Literal Clip (toEnum 0)) rest
-          | ">"  <- ind = go0 True (Folded Clip (toEnum 0)) rest
+          | "|"  <- ind = go0 True (Literal Clip IndentAuto) rest
+          | ">"  <- ind = go0 True (Folded Clip IndentAuto) rest
 
           | "+"  <- ind = go0 ii (chn sty Keep) rest
           | "-"  <- ind = go0 ii (chn sty Strip) rest

--- a/src/Data/YAML/Event.hs
+++ b/src/Data/YAML/Event.hs
@@ -300,9 +300,12 @@ goNode0 DInfo {..} = goNode
 
         go0 _ _ xs = err xs
 
+        chn :: ScalarStyle -> Chomp -> ScalarStyle
         chn (Literal _ digit) chmp = Literal chmp digit
         chn (Folded _ digit) chmp = Folded chmp digit
         chn _ _ = error "impossible"
+
+        chn' :: ScalarStyle -> Int -> ScalarStyle
         chn' (Literal b _) digit = Literal b (toEnum digit)
         chn' (Folded b _) digit = Folded b (toEnum digit)
         chn' _ _ = error "impossible"

--- a/src/Data/YAML/Event.hs
+++ b/src/Data/YAML/Event.hs
@@ -286,12 +286,12 @@ goNode0 DInfo {..} = goNode
         go0 ii sty (Y.Token { Y.tCode = Y.Indicator, Y.tText = ind } : rest)
           | "'"  <- ind = go' ii "" SingleQuoted rest
           | "\"" <- ind = go' ii "" DoubleQuoted rest
-          | "|"  <- ind = go0 True Literal rest
-          | ">"  <- ind = go0 True Folded rest
+          | "|"  <- ind = go0 True (Literal Clip (toEnum 0)) rest
+          | ">"  <- ind = go0 True (Folded Clip (toEnum 0)) rest
 
-          | "+"  <- ind = go0 ii sty rest
-          | "-"  <- ind = go0 ii sty rest
-          | [c]  <- ind, '1' <= c, c <= '9' = go0 False sty rest
+          | "+"  <- ind = go0 ii (chn sty Keep) rest
+          | "-"  <- ind = go0 ii (chn sty Strip) rest
+          | [c]  <- ind, '1' <= c, c <= '9' = go0 False (chn' sty (C.digitToInt c)) rest
 
         go0 ii sty (Y.Token { Y.tCode = Y.Text, Y.tText = t } : rest)      = go' ii t sty rest
         go0 ii sty (Y.Token { Y.tCode = Y.LineFold } : rest)               = go' ii " " sty rest
@@ -299,6 +299,13 @@ goNode0 DInfo {..} = goNode
         go0 _  sty (Y.Token { Y.tCode = Y.EndScalar } : rest)              = Right (Scalar manchor tag sty mempty) : cont rest
 
         go0 _ _ xs = err xs
+
+        chn (Literal _ digit) chmp = Literal chmp digit
+        chn (Folded _ digit) chmp = Folded chmp digit
+        chn _ _ = error "impossible"
+        chn' (Literal b _) digit = Literal b (toEnum digit)
+        chn' (Folded b _) digit = Folded b (toEnum digit)
+        chn' _ _ = error "impossible"
 
         ----------------------------------------------------------------------------
 

--- a/src/Data/YAML/Event/Internal.hs
+++ b/src/Data/YAML/Event/Internal.hs
@@ -77,15 +77,18 @@ data ScalarStyle = Plain
                  | Literal !Chomp !IndentOfs
                  | Folded !Chomp !IndentOfs
                  deriving (Eq,Ord,Show)
+
+-- | <https://yaml.org/spec/1.2/spec.html#id2794534 Block Chomping Indicator>
+--  
 -- @since 0.2.0
 data Chomp = Strip -- ^ Remove all trailing line breaks and shows the presence of @-@ chomping indicator. 
-           | Clip  -- ^ Keep first trailing line break; this also the default behavior used if no explicit chomping indicator is specified
-           | Keep  -- ^ Keep all trailing line breaks and shows the presence of @-@ chomping indicator.
+           | Clip  -- ^ Keep first trailing line break; this also the default behavior used if no explicit chomping indicator is specified.
+           | Keep  -- ^ Keep all trailing line breaks and shows the presence of @+@ chomping indicator.
            deriving (Eq,Ord,Show)
 
 -- | Block Indentation Indicator
 --
--- @IndentAuto@ is the special case for auto Block Indentation Indicator
+-- 'IndentAuto' is the special case for auto Block Indentation Indicator
 --
 -- @since 0.2.0
 data IndentOfs = IndentAuto | IndentOfs1 | IndentOfs2 | IndentOfs3 | IndentOfs4 | IndentOfs5 | IndentOfs6 | IndentOfs7 | IndentOfs8 | IndentOfs9

--- a/src/Data/YAML/Event/Internal.hs
+++ b/src/Data/YAML/Event/Internal.hs
@@ -9,6 +9,8 @@ module Data.YAML.Event.Internal
     , Event(..)
     , Directives(..)
     , ScalarStyle(..)
+    , Chomp(..)
+    , IndentOfs(..)
     , NodeStyle(..)
     , scalarNodeStyle
     , Tag(..), untagged, isUntagged, tagToText
@@ -72,9 +74,17 @@ data Directives = NoDirEndMarker    -- ^ no directives and also no @---@ marker
 data ScalarStyle = Plain
                  | SingleQuoted
                  | DoubleQuoted
-                 | Literal
-                 | Folded
+                 | Literal !Chomp !IndentOfs
+                 | Folded !Chomp !IndentOfs
                  deriving (Eq,Ord,Show)
+
+data Chomp = Strip -- ^ Remove all trailing line breaks.
+           | Clip  -- ^ Keep first trailing line break.
+           | Keep  -- ^ Keep all trailing line breaks.
+           deriving (Eq,Ord,Show)
+
+data IndentOfs = IndentAuto | IndentOfs1 | IndentOfs2 | IndentOfs3 | IndentOfs4 | IndentOfs5 | IndentOfs6 | IndentOfs7 | IndentOfs8 | IndentOfs9
+                  deriving (Eq, Ord, Show, Enum)
 
 -- | Node style
 --
@@ -90,8 +100,8 @@ scalarNodeStyle :: ScalarStyle -> NodeStyle
 scalarNodeStyle Plain        = Flow
 scalarNodeStyle SingleQuoted = Flow
 scalarNodeStyle DoubleQuoted = Flow
-scalarNodeStyle Literal      = Block
-scalarNodeStyle Folded       = Block
+scalarNodeStyle (Literal _ _)  = Block
+scalarNodeStyle (Folded _ _ )  = Block
 
 -- | YAML Anchor identifiers
 type Anchor = Text

--- a/src/Data/YAML/Event/Internal.hs
+++ b/src/Data/YAML/Event/Internal.hs
@@ -77,12 +77,17 @@ data ScalarStyle = Plain
                  | Literal !Chomp !IndentOfs
                  | Folded !Chomp !IndentOfs
                  deriving (Eq,Ord,Show)
-
-data Chomp = Strip -- ^ Remove all trailing line breaks.
-           | Clip  -- ^ Keep first trailing line break.
-           | Keep  -- ^ Keep all trailing line breaks.
+-- @since 0.2.0
+data Chomp = Strip -- ^ Remove all trailing line breaks and shows the presence of @-@ chomping indicator. 
+           | Clip  -- ^ Keep first trailing line break; this also the default behavior used if no explicit chomping indicator is specified
+           | Keep  -- ^ Keep all trailing line breaks and shows the presence of @-@ chomping indicator.
            deriving (Eq,Ord,Show)
 
+-- | Block Indentation Indicator
+--
+-- @IndentAuto@ is the special case for auto Block Indentation Indicator
+--
+-- @since 0.2.0
 data IndentOfs = IndentAuto | IndentOfs1 | IndentOfs2 | IndentOfs3 | IndentOfs4 | IndentOfs5 | IndentOfs6 | IndentOfs7 | IndentOfs8 | IndentOfs9
                   deriving (Eq, Ord, Show, Enum)
 

--- a/src/Data/YAML/Event/Writer.hs
+++ b/src/Data/YAML/Event/Writer.hs
@@ -164,7 +164,7 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
         BlockOut -> anchorTag'' (Left ws) anc tag (eol <> mkInd n' <> "-" <> go n' False c' xs g)
 
         BlockIn
-          | not sol && n == 0 {- "---" case -} -> goSeq n sol BlockOut anc tag sty xs cont
+          | not sol && n == 0 {- "- -" case -} -> goSeq n sol BlockOut anc tag sty xs cont
           | otherwise -> (if sol then mempty else ws) <> anchorTag'' (Right (eol <> mkInd n')) anc tag ("-" <> go n' False c' xs g)
 
         BlockKey -> error ("sequence in block-key context not supported")
@@ -214,9 +214,11 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
       Literal chm iden -> pfx $ "|" <> goChomp chm <> goDigit iden <> g (T.lines t) (fromEnum iden) cont
 
       where
+        goDigit :: IndentOfs -> T.B.Builder
         goDigit iden = let ch = C.intToDigit.fromEnum $ iden
                        in if(ch == '0') then mempty else T.B.singleton ch
 
+        goChomp :: Chomp -> T.B.Builder
         goChomp chm = case chm of
            Strip -> T.B.singleton '-'
            Clip -> mempty

--- a/src/Data/YAML/Event/Writer.hs
+++ b/src/Data/YAML/Event/Writer.hs
@@ -164,7 +164,7 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
         BlockOut -> anchorTag'' (Left ws) anc tag (eol <> mkInd n' <> "-" <> go n' False c' xs g)
 
         BlockIn
-          | not sol && n == 0 {- "- -" case -} -> goSeq n sol BlockOut anc tag sty xs cont
+          | not sol && n == 0 {- "---" case -} -> goSeq n sol BlockOut anc tag sty xs cont
           | otherwise -> (if sol then mempty else ws) <> anchorTag'' (Right (eol <> mkInd n')) anc tag ("-" <> go n' False c' xs g)
 
         BlockKey -> error ("sequence in block-key context not supported")
@@ -193,7 +193,7 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
       Plain -- empty scalars
         | t == "", Nothing <- anc, Tag Nothing <- tag -> contEol -- not even node properties
         | sol, t == "" ->             anchorTag0 anc tag (if c == BlockKey then ws <> cont else contEol)
-        | t == "", BlockKey <- c   -> anchorTag0 anc tag (if c == BlockKey then ws <> cont else contEol) -- unnecessary if 
+        | t == "", BlockKey <- c   -> anchorTag0 anc tag (ws <> cont)
         | t == ""      -> anchorTag'' (Left ws) anc tag contEol
 
       Plain           -> pfx $
@@ -289,7 +289,6 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
       | l < 0     = error (show l)
       | otherwise = T.B.fromText (T.replicate l "  ")
 
-    mkInd' 0    = mempty
     mkInd' 1 = " "
     mkInd' 2 = "  "
     mkInd' 3 = "   "


### PR DESCRIPTION
1. These changes help to preserve Block Scalar Headers information
2. Fix bugs that occurred after a round-trip
3. These changes will not become a source for some other errors/problems.

Stats on YAML-test suite
```
done -- passed: 316 (ev: 32, ev+json: 93, ev+json+yaml: 120, err: 71) / failed: 2 (err: 2, ev:0, json:0, yaml:0, ok:0)
```