### PR TITLE
Features to preserve Flow Mapping and Flow sequence

### DIFF
--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -350,7 +350,10 @@ cmdRunTml args = do
           if evs'' == testEvDat
              then do
 
-               let outYamlDatIut = writeEvents YT.UTF8 evs'
+               let toBlockStyle (YE.SequenceStart a b _ ) = YE.SequenceStart a b YE.Block
+                   toBlockStyle (YE.MappingStart a b _ ) = YE.MappingStart a b YE.Block
+                   toBlockStyle a = a
+                   outYamlDatIut = writeEvents YT.UTF8 (map toBlockStyle evs')
                    outYamlEvsIut = either (const []) (map (ev2str False)) $ sequence $ parseEvents outYamlDatIut
 
                unless (outYamlEvsIut == evs'') $ do


### PR DESCRIPTION
1. These changes help to preserve Flow style Mapping and Flow style Sequence information
2. Fix bugs that occurred after a round-trip
3. Minor code improvements 
4. These changes will not become a source for some other errors/problems.

Stats on YAML-test suite
```
done -- passed: 316 (ev: 32, ev+json: 128, ev+json+yaml: 85, err: 71) / failed: 2 (err: 2, ev:0, json:0, yaml:0, ok:0)
```

It was also tested on some additional examples which can be found [here](https://github.com/vijayphoenix/GSoC/tree/master/examples)