### PR TITLE
Fix issue #22

### DIFF
--- a/src/Data/YAML/Event/Writer.hs
+++ b/src/Data/YAML/Event/Writer.hs
@@ -359,8 +359,8 @@ putNode = \docMarker -> go (-1 :: Int) (not docMarker) BlockIn
     wsSol sol = if sol then mempty else ws
 
 escapeDQ :: Text -> Text
-escapeDQ t -- TODO: review "printable" definition in YAML 1.2 spec
-  | T.all (\c -> C.isPrint c && c /= '\n' && c /= '"') t = t
+escapeDQ t
+  | T.all (\c -> C.isPrint c && c /= '\\' && c /= '"') t = t
   | otherwise = T.concatMap escapeChar t
 
 escapeChar :: Char -> Text


### PR DESCRIPTION
* Fix #22
* Reviewed the [printable](https://yaml.org/spec/1.2/spec.html#nb-double-char) definition in YAML 1.2. 
* Source of Bug
```
> Data.Char.isPrint '\\'
True
> Data.Char.isPrint '\n'
False
```

No side-effects observed on YAML test suite stats
```
done -- passed: 316 (ev: 32, ev+json: 93, ev+json+yaml: 120, err: 71) / failed: 2 (err: 2, ev:0, json:0, yaml:0, ok:0)
```