### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -78,7 +78,7 @@ library
                        TypeSynonymInstances
 
   build-depends:       base         >=4.5   && <4.15
-                     , bytestring   >=0.9   && <0.11
+                     , bytestring   >=0.9   && <0.12
                      , containers   >=0.4.2 && <0.7
                      , deepseq      >=1.3.0 && <1.5
                      , text         >=1.2.3 && <1.3


### PR DESCRIPTION
Tested locally with

```
$ cabal test -O0 --constraint 'bytestring>=0.11' all --allow-newer=bytestring --enable-tests
```