### PR TITLE
Allow base 4.15

### DIFF
--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -77,7 +77,7 @@ library
                        Trustworthy
                        TypeSynonymInstances
 
-  build-depends:       base         >=4.5   && <4.15
+  build-depends:       base         >=4.5   && <4.16
                      , bytestring   >=0.9   && <0.11
                      , containers   >=0.4.2 && <0.7
                      , deepseq      >=1.3.0 && <1.5


### PR DESCRIPTION
Tested locally with

    cabal test -O0 --allow-newer=microaeson:base,QuickCheck,tasty --enable-tests

Closes #54.