### PR TITLE
v0.2.1.2: allow containers-0.7

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/haskell-CI/haskell-ci
+# For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20230827
+# version: 0.17.20230928
 #
-# REGENDATA ("0.17.20230827",["github","HsYAML.cabal"])
+# REGENDATA ("0.17.20230928",["github","HsYAML.cabal"])
 #
 name: Haskell-CI
 on:
@@ -31,19 +31,19 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:focal
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230822
+          - compiler: ghc-9.8.0.20230919
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230822
+            compilerVersion: 9.8.0.20230919
             setup-method: ghcup
             allow-failure: true
-          - compiler: ghc-9.6.2
+          - compiler: ghc-9.6.3
             compilerKind: ghc
-            compilerVersion: 9.6.2
+            compilerVersion: 9.6.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.7
@@ -214,7 +214,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: source
       - name: initial cabal.project for sdist

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 See also http://pvp.haskell.org/faq
 
+### 0.2.1.2
+
+_2023-09-29_
+
+* Add `default-extensions: TypeOperators` to silence warning under GHC ≥ 9.4.
+* Support latest versions of dependencies.
+* Tested with GHC 7.10 - 9.8.0
+
 ### 0.2.1.1
 
 _2022-05-11_

--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.14
 name:                HsYAML
-version:             0.2.1.1
+version:             0.2.1.2
 
 synopsis:            Pure Haskell YAML 1.2 processor
 homepage:            https://github.com/haskell-hvr/HsYAML
@@ -16,7 +16,7 @@ category:            Text
 build-type:          Simple
 tested-with:
   GHC == 9.8.0
-  GHC == 9.6.2
+  GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8
   GHC == 9.0.2
@@ -97,7 +97,7 @@ library
 
   build-depends:       base         >= 4.5      && < 5
                      , bytestring   >= 0.9      && < 0.13
-                     , containers   >= 0.4.2    && < 0.7
+                     , containers   >= 0.4.2    && < 0.8
                      , deepseq      >= 1.3.0    && < 1.6
                      , text         >= 1.2.3    && < 2.2
                      , mtl          >= 2.2.1    && < 2.4


### PR DESCRIPTION
Version bump & Hackage release to get the `TypeOperators` language extension activated by default.

Candidate: https://hackage.haskell.org/package/HsYAML-0.2.1.2/candidate
