### PR TITLE
Release v0.2.1.3 for ghc 9.8.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,22 +8,18 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.17.20230928
+# version: 0.17.20231012
 #
-# REGENDATA ("0.17.20230928",["github","HsYAML.cabal"])
+# REGENDATA ("0.17.20231012",["github","HsYAML.cabal"])
 #
 name: Haskell-CI
 on:
   push:
     branches:
       - master
-      - ci-*
-      - release*
   pull_request:
     branches:
       - master
-      - ci-*
-      - release*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -36,11 +32,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.0.20230919
+          - compiler: ghc-9.8.1
             compilerKind: ghc
-            compilerVersion: 9.8.0.20230919
+            compilerVersion: 9.8.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.6.3
             compilerKind: ghc
             compilerVersion: 9.6.3
@@ -69,27 +65,27 @@ jobs:
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.6.5
             compilerKind: ghc
             compilerVersion: 8.6.5
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.2.2
             compilerKind: ghc
             compilerVersion: 8.2.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.0.2
             compilerKind: ghc
             compilerVersion: 8.0.2
-            setup-method: hvr-ppa
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-7.10.3
             compilerKind: ghc
@@ -101,7 +97,7 @@ jobs:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
@@ -150,7 +146,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           if [ $((HCNUMVER >= 80000)) -ne 0 ] ; then echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV" ; else echo "ARG_TESTS=--disable-tests" >> "$GITHUB_ENV" ; fi
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -179,18 +175,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -241,12 +225,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package HsYAML" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
-          allow-newer: bytestring
-          allow-newer: text
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(HsYAML)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
@@ -284,23 +263,6 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
-      - name: prepare for constraint sets
-        run: |
-          rm -f cabal.project.local
-      - name: constraint set bytestring-0.12
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>=0.12' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>=0.12' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>=0.12' all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring ^>=0.12' all ; fi
-      - name: constraint set text-2.1
-        run: |
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.1' all --dry-run ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.1' --dependencies-only -j2 all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.1' all ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='text ^>=2.1' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 See also http://pvp.haskell.org/faq
 
+### 0.2.1.3
+
+_2023-10-14_
+
+* Pacify `x-partial` warning of GHC 9.8
+* Tested with GHC 7.10 - 9.8.1
+
 ### 0.2.1.2
 
 _2023-09-29_

--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.14
 name:                HsYAML
-version:             0.2.1.2
+version:             0.2.1.3
 
 synopsis:            Pure Haskell YAML 1.2 processor
 homepage:            https://github.com/haskell-hvr/HsYAML

--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -15,7 +15,7 @@ copyright:           2015-2018 Herbert Valerio Riedel
 category:            Text
 build-type:          Simple
 tested-with:
-  GHC == 9.8.0
+  GHC == 9.8.1
   GHC == 9.6.3
   GHC == 9.4.7
   GHC == 9.2.8

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,23 +1,23 @@
-branches: master ci-* release*
+branches: master
 
 -- Dropping building tests on GHC 7.x which ships a too old bytestring package.
 -- installed: +all -binary -bytestring -transformers -text
 tests: >=8.0
 installed: +all
 
-constraint-set text-2.1
-  ghc: >=8.2
-  constraints: text ^>=2.1
-  tests: True
-  run-tests: True
+-- constraint-set text-2.1
+--   ghc: >=8.2
+--   constraints: text ^>=2.1
+--   tests: True
+--   run-tests: True
 
-constraint-set bytestring-0.12
-  ghc: >=8.2
-  constraints: bytestring ^>=0.12
-  tests: True
-  run-tests: True
+-- constraint-set bytestring-0.12
+--   ghc: >=8.2
+--   constraints: bytestring ^>=0.12
+--   tests: True
+--   run-tests: True
 
--- For constraint-sets
-raw-project
-  allow-newer: bytestring
-  allow-newer: text
+-- -- For constraint-sets
+-- raw-project
+--   allow-newer: bytestring
+--   allow-newer: text

--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -146,7 +146,7 @@ cmdYaml2Token = do
     forM_  lgrp $ \YT.Token{..} -> do
       let tText' | null tText = ""
                  | any (== ' ') tText = replicate tLineChar ' ' ++ show tText
-                 | otherwise  = replicate (tLineChar+1) ' ' ++ tail (init (show tText))
+                 | otherwise  = replicate (tLineChar+1) ' ' ++ drop 1 (init (show tText))
       hPutStrLn stdout $ printf "<stdin>:%d:%d: %-15s| %s" tLine tLineChar (show tCode) tText'
     hPutStrLn stdout ""
   hFlush stdout

--- a/src/Data/YAML/Event.hs
+++ b/src/Data/YAML/Event.hs
@@ -174,13 +174,19 @@ parseEvents = \bs0 -> fixUpEOS $ Right (EvPos StreamStart initPos) : (go0 $ filt
 
     -- consume {Begin,End}Directives and emit DocumentStart event
     goDirs :: DInfo -> Tok2EvStream
-    goDirs m (Y.Token { Y.tCode = Y.BeginDirective } : rest) = goDir1 m rest
-    goDirs m toks0@(Y.Token { Y.tCode = Y.BeginComment} : _) = goComment toks0 (goDirs m)
+    goDirs m (Y.Token { Y.tCode = Y.BeginDirective } : rest) =
+      goDir1 m rest
+    goDirs m toks0@(Y.Token { Y.tCode = Y.BeginComment} : _) =
+      goComment toks0 (goDirs m)
     goDirs m (tok@Y.Token { Y.tCode = Y.DirectivesEnd } : rest)
       | Just (1,mi) <- diVer m = Right (getEvPos (DocumentStart (DirEndMarkerVersion mi)) tok) : go1 m rest
       | otherwise              = Right (getEvPos (DocumentStart DirEndMarkerNoVersion) tok) : go1 m rest
-    goDirs _ xs@(Y.Token { Y.tCode = Y.BeginDocument } : _) = err xs
-    goDirs m xs = Right ( getEvPos (DocumentStart NoDirEndMarker) (head xs) ): go1 m xs
+    goDirs _ xs@(Y.Token { Y.tCode = Y.BeginDocument } : _) =
+      err xs
+    goDirs m xs@(tok : _) =
+      Right (getEvPos (DocumentStart NoDirEndMarker) tok) : go1 m xs
+    goDirs _ xs =
+      err xs
 
     -- single directive
     goDir1 :: DInfo -> [Y.Token] -> EvStream


### PR DESCRIPTION
- Pacify `x-partial` warning of GHC 9.8.1
- Bump Haskell CI to GHC 9.8.1

Candidate at: https://hackage.haskell.org/package/HsYAML-0.2.1.3/candidate