### PR TITLE
v0.2.1.4: drop support for GHC 7, add support for LTS 11.22 and up

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.19.20240416
+# version: 0.19.20240422
 #
-# REGENDATA ("0.19.20240416",["github","HsYAML.cabal"])
+# REGENDATA ("0.19.20240422",["github","HsYAML.cabal"])
 #
 name: Haskell-CI
 on:
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:focal
+      image: buildpack-deps:jammy
     continue-on-error: ${{ matrix.allow-failure }}
     strategy:
       matrix:
@@ -42,9 +42,9 @@ jobs:
             compilerVersion: 9.8.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.6.5
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.6.5
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -1,0 +1,97 @@
+name: Stack build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  stack:
+    name: ${{ matrix.os }} Stack ${{ matrix.plan.resolver }} / ${{ matrix.plan.ghc }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        plan:
+          - ghc: '9.8.2'
+            resolver: 'nightly-2024-04-25'
+          - ghc: '9.6.4'
+            resolver: 'lts-22.18'
+          - ghc: '9.4.8'
+            resolver: 'lts-21.25'
+          - ghc: '9.2.8'
+            resolver: 'lts-20.26'
+          - ghc: '9.0.2'
+            resolver: 'lts-19.33'
+          - ghc: '8.10.7'
+            resolver: 'lts-18.28'
+          - ghc: '8.8.4'
+            resolver: 'lts-16.31'
+          - ghc: '8.6.5'
+            resolver: 'lts-14.27'
+          - ghc: '8.4.4'
+            resolver: 'lts-12.26'
+          - ghc: '8.2.2'
+            resolver: 'lts-11.22'
+          # LTS 9.21 does not have recent enough parsec and test
+          # - ghc: '8.0.2'
+          #   resolver: 'lts-9.21'
+
+        include:
+          - os: windows-latest
+            plan:
+              ghc: '9.8.2'
+              resolver: 'nightly-2024-04-25'
+
+          - os: macos-latest
+            plan:
+              ghc: '9.8.2'
+              resolver: 'nightly-2024-04-25'
+
+    runs-on: ${{ matrix.os }}
+    env:
+      STACK: stack --system-ghc --no-terminal --resolver ${{ matrix.plan.resolver }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: haskell-actions/setup@latest
+      id: setup
+      with:
+        ghc-version: ${{ matrix.plan.ghc }}
+        enable-stack: true
+        cabal-update: false
+
+    - uses: actions/cache/restore@v4
+      id: cache
+      env:
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-
+      with:
+        path: ${{ steps.setup.outputs.stack-root }}
+        key:  ${{ env.key }}-${{ github.sha }}
+        restore-keys: ${{ env.key }}-
+
+    - name: Configure
+      run: $STACK init
+
+    - name: Install dependencies
+      run: $STACK test --only-dependencies
+
+    - name: Build
+      run: $STACK test --haddock --no-haddock-deps --no-run-tests
+
+    - name: Test
+      run: $STACK -j 1 test --haddock --no-haddock-deps
+
+    - uses: actions/cache/save@v4
+      if: always() && steps.cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup.outputs.stack-root }}
+        key:  ${{ steps.cache.outputs.cache-primary-key }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /dist/
-/.ghc.environment.*
 /dist-newstyle/
+/.ghc.environment.*
+/.stack-work/
+/stack*.yaml.lock
 *~

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 See also http://pvp.haskell.org/faq
 
+### 0.2.1.4
+
+_2024-04-25_
+
+* Drop support for GHC 7
+* Testsuite: relax lower bounds to accommodate LTS 11.22 (GHC 8.2) for new Stack CI
+* Tested with GHC 8.0 - 9.10.0 (alpha3)
+
 ### 0.2.1.3
 
 _2023-10-14_

--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -1,7 +1,6 @@
 cabal-version:       1.14
 name:                HsYAML
-version:             0.2.1.3
-x-revision:          1
+version:             0.2.1.4
 
 synopsis:            Pure Haskell YAML 1.2 processor
 homepage:            https://github.com/haskell-hvr/HsYAML
@@ -18,7 +17,7 @@ build-type:          Simple
 tested-with:
   GHC == 9.10.0
   GHC == 9.8.2
-  GHC == 9.6.4
+  GHC == 9.6.5
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -28,13 +27,6 @@ tested-with:
   GHC == 8.4.4
   GHC == 8.2.2
   GHC == 8.0.2
-  -- Skip testing on GHC 7.10 as it does not install with GHCup on ubuntu-22.04
-  -- GHC == 7.10.3
-  -- Skip testing on GHC 7.8 as it ships a too old 'transformers'
-  -- GHC == 7.8.4
-  -- Skip testing these legacy GHC versions:
-  -- GHC == 7.6.3
-  -- GHC == 7.4.2
 
 description:
   @HsYAML@ is a [YAML 1.2](http://yaml.org/spec/1.2/spec.html) processor, i.e. a library for parsing and serializing YAML documents.
@@ -98,7 +90,7 @@ library
                        Trustworthy
                        TypeSynonymInstances
 
-  build-depends:       base         >= 4.5      && < 5
+  build-depends:       base         >= 4.9      && < 5
                      , bytestring   >= 0.9      && < 0.13
                      , containers   >= 0.4.2    && < 0.8
                      , deepseq      >= 1.3.0    && < 1.6
@@ -107,17 +99,9 @@ library
                      , parsec       >= 3.1.13.0 && < 3.2
                      , transformers >= 0.4      && < 0.7
 
-  -- for GHC.Generics
-  if impl(ghc < 7.6)
-    build-depends: ghc-prim
-
-  if !impl(ghc >= 8.0)
-    build-depends:     fail         >= 4.9.0.0  && < 4.10
-
-  if !impl(ghc >= 7.10)
-    build-depends:     nats         >= 1.1.2    && < 1.2
-
-  ghc-options:         -Wall
+  ghc-options:
+    -Wall
+    -Wcompat
 
 executable yaml-test
   hs-source-dirs: src-test
@@ -160,6 +144,7 @@ test-suite tests
                  , containers
                  , mtl
                    -- non-inherited
-                 , QuickCheck       == 2.14.*
-                 , tasty            >= 1.4    && < 1.6
-                 , tasty-quickcheck == 0.10.*
+                   -- lower bounds chosen from lts-11.22 (GHC 8.2)
+                 , QuickCheck       >= 2.10.1   && < 2.16
+                 , tasty            >= 1.0.1.1  && < 1.6
+                 , tasty-quickcheck >= 0.9.2    && < 0.11


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/HsYAML-0.2.1.4/candidate