### PR TITLE
v0.2.1.5: Drop support for pre GHC 8.0 dependencies, allow newer containers

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20240517
+# version: 0.19.20250216
 #
-# REGENDATA ("0.19.20240517",["github","HsYAML.cabal"])
+# REGENDATA ("0.19.20250216",["github","HsYAML.cabal"])
 #
 name: Haskell-CI
 on:
@@ -23,7 +23,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -32,19 +32,24 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.1
+            compilerKind: ghc
+            compilerVersion: 9.12.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.5
+          - compiler: ghc-9.6.6
             compilerKind: ghc
-            compilerVersion: 9.6.5
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -94,15 +99,29 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.10.3.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -113,21 +132,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.3.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
           echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -204,6 +214,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package HsYAML" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: containers
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(HsYAML)$/; }' >> cabal.project.local
           cat cabal.project
@@ -242,9 +253,19 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set containers-0.8
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -20,10 +20,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         plan:
-          - ghc: '9.8.2'
-            resolver: 'nightly-2024-06-22'
-          - ghc: '9.6.5'
-            resolver: 'lts-22.26'
+          - ghc: '9.10.1'
+            resolver: 'nightly-2025-03-11'
+          - ghc: '9.8.4'
+            resolver: 'lts-23.14'
+          - ghc: '9.6.6'
+            resolver: 'lts-22.43'
           - ghc: '9.4.8'
             resolver: 'lts-21.25'
           - ghc: '9.2.8'
@@ -38,8 +40,9 @@ jobs:
             resolver: 'lts-14.27'
           - ghc: '8.4.4'
             resolver: 'lts-12.26'
-          - ghc: '8.2.2'
-            resolver: 'lts-11.22'
+          # Stack 3 dropped support for GHC 8.2
+          # - ghc: '8.2.2'
+          #   resolver: 'lts-11.22'
           # LTS 9.21 does not have recent enough parsec and test
           # - ghc: '8.0.2'
           #   resolver: 'lts-9.21'
@@ -47,13 +50,13 @@ jobs:
         include:
           - os: windows-latest
             plan:
-              ghc: '9.8.2'
-              resolver: 'nightly-2024-06-22'
+              ghc: '9.10.1'
+              resolver: 'nightly-2025-03-11'
 
           - os: macos-latest
             plan:
-              ghc: '9.8.2'
-              resolver: 'nightly-2024-06-22'
+              ghc: '9.10.1'
+              resolver: 'nightly-2025-03-11'
 
     runs-on: ${{ matrix.os }}
     env:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,36 +1,44 @@
-See also http://pvp.haskell.org/faq
+### 0.2.1.5
+
+_2025-03-11, Andreas Abel_
+
+* Drop support for old dependencies predating LTS 7.24 (GHC 8.0).
+* Relax bound on `containers`.
+* Tested with GHC 8.0 - 9.12.1.
 
 ### 0.2.1.4
 
-_2024-04-25_
+_2024-04-25, Andreas Abel_
 
-* Drop support for GHC 7
-* Testsuite: relax lower bounds to accommodate LTS 11.22 (GHC 8.2) for new Stack CI
-* Tested with GHC 8.0 - 9.10.0 (alpha3)
+* Drop support for GHC 7.
+* Testsuite: relax lower bounds to accommodate LTS 11.22 (GHC 8.2) for new Stack CI.
+* Tested with GHC 8.0 - 9.10.0 (alpha3).
 
 ### 0.2.1.3
 
-_2023-10-14_
+_2023-10-14, Andreas Abel_
 
-* Pacify `x-partial` warning of GHC 9.8
-* Tested with GHC 7.10 - 9.8.1
+* Pacify `x-partial` warning of GHC 9.8.
+* Tested with GHC 7.10 - 9.8.1.
 
 ### 0.2.1.2
 
-_2023-09-29_
+_2023-09-29, Andreas Abel_
 
 * Add `default-extensions: TypeOperators` to silence warning under GHC ≥ 9.4.
 * Support latest versions of dependencies.
-* Tested with GHC 7.10 - 9.8.0
+* Tested with GHC 7.10 - 9.8.0.
 
 ### 0.2.1.1
 
-_2022-05-11_
+_2022-05-11, Andreas Abel_
 
-* Compatibility with `mtl-2.3`
-* Tested with GHC 7.4 - 9.2
+* Compatibility with `mtl-2.3`.
+* Tested with GHC 7.4 - 9.2.
 
 ### 0.2.1.0
+
+_2019-10-06, Herbert Valerio Riedel_
 
 * Define `Functor Doc` instance ([#33](https://github.com/haskell-hvr/HsYAML/issues/33))
 * New `withScalar` function and also define `ToYAML Scalar` and `FromYAML Scalar` instances

--- a/HsYAML.cabal
+++ b/HsYAML.cabal
@@ -1,7 +1,6 @@
 cabal-version:       1.14
 name:                HsYAML
-version:             0.2.1.4
-x-revision:          1
+version:             0.2.1.5
 
 synopsis:            Pure Haskell YAML 1.2 processor
 homepage:            https://github.com/haskell-hvr/HsYAML
@@ -16,9 +15,10 @@ copyright:           2015-2018 Herbert Valerio Riedel
 category:            Text
 build-type:          Simple
 tested-with:
+  GHC == 9.12.1
   GHC == 9.10.1
-  GHC == 9.8.2
-  GHC == 9.6.5
+  GHC == 9.8.4
+  GHC == 9.6.6
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -91,14 +91,16 @@ library
                        Trustworthy
                        TypeSynonymInstances
 
-  build-depends:       base         >= 4.9      && < 5
-                     , bytestring   >= 0.9      && < 0.13
-                     , containers   >= 0.4.2    && < 0.8
-                     , deepseq      >= 1.3.0    && < 1.6
-                     , text         >= 1.2.3    && < 2.2
-                     , mtl          >= 2.2.1    && < 2.4
-                     , parsec       >= 3.1.13.0 && < 3.2
-                     , transformers >= 0.4      && < 0.7
+  build-depends:
+    -- Lower bounds chosen from LTS-7.24 (GHC 8.0.1)
+      base         >= 4.9      && < 5
+    , bytestring   >= 0.10.8.1 && < 0.13
+    , containers   >= 0.5.7.1  && < 1
+    , deepseq      >= 1.4.2.0  && < 1.6
+    , text         >= 1.2.3    && < 2.2
+    , mtl          >= 2.2.1    && < 2.4
+    , parsec       >= 3.1.13.0 && < 3.2
+    , transformers >= 0.5.2.0  && < 0.7
 
   ghc-options:
     -Wall
@@ -114,7 +116,7 @@ executable yaml-test
   if flag(exe)
     build-depends: HsYAML
                    -- inherited constraints
-                 , bytestring >= 0.10.8.0
+                 , bytestring
                  , base
                  , text
                  , containers

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,19 +1,11 @@
 branches: master
 installed: +all
 
--- constraint-set text-2.1
---   ghc: >=8.2
---   constraints: text ^>=2.1
---   tests: True
---   run-tests: True
+constraint-set containers-0.8
+  ghc: >= 8.2
+  constraints: containers ^>=0.8
+  tests: True
+  run-tests: True
 
--- constraint-set bytestring-0.12
---   ghc: >=8.2
---   constraints: bytestring ^>=0.12
---   tests: True
---   run-tests: True
-
--- -- For constraint-sets
--- raw-project
---   allow-newer: bytestring
---   allow-newer: text
+raw-project
+  allow-newer: containers

--- a/src/Util.hs
+++ b/src/Util.hs
@@ -42,11 +42,7 @@ import           Data.Char                    as X (chr, ord)
 import           Data.Map                     as X (Map)
 import qualified Data.Map                     as Map
 import           Data.Monoid                  as X (Monoid (mappend, mempty))
-#if MIN_VERSION_base(4,9,0)
 import           Data.Semigroup               ((<>))
-#else
-import           Data.Monoid                  ((<>))
-#endif
 import qualified Data.ByteString              as BS
 import qualified Data.ByteString.Lazy         as BS.L
 import           Data.Set                     as X (Set)
@@ -63,26 +59,6 @@ import           Text.Read
 liftEither' :: MonadError e m => Either e a -> m a
 liftEither' = either throwError return
 
-
-#if !MIN_VERSION_base(4,6,0)
-
--- | Parse a string using the 'Read' instance. Succeeds if there is
--- exactly one valid result.
-readMaybe :: Read a => String -> Maybe a
-readMaybe = either (const Nothing) id . readEither
-
--- | Parse a string using the 'Read' instance. Succeeds if there is
--- exactly one valid result. A 'Left' value indicates a parse error.
-readEither :: Read a => String -> Either String a
-readEither s = case [ x | (x,"") <- readPrec_to_S read' minPrec s ] of
-                 [x] -> Right x
-                 []  -> Left "Prelude.read: no parse"
-                 _   -> Left "Prelude.read: ambiguous parse"
- where
-  read' = do x <- readPrec
-             Text.Read.lift P.skipSpaces
-             return x
-#endif
 
 -- | Succeeds if the 'Integral' value is in the bounds of the given Data type.
 -- 'Nothing' indicates that the value is outside the bounds.
@@ -115,8 +91,4 @@ mapInsertNoDupe kx x t = case Map.insertLookupWithKey (\_ a _ -> a) kx x t of
 -- O(n) Convert a lazy 'BS.L.ByteString' into a strict 'BS.ByteString'.
 {-# INLINE bsToStrict #-}
 bsToStrict :: BS.L.ByteString -> BS.ByteString
-#if MIN_VERSION_bytestring(0,10,0)
 bsToStrict = BS.L.toStrict
-#else
-bsToStrict = BS.concat . BS.L.toChunks
-#endif


### PR DESCRIPTION
Candidate: https://hackage.haskell.org/package/HsYAML-0.2.1.5/candidate